### PR TITLE
refactor(input::to_numerical): Refactor control flow

### DIFF
--- a/my_rusttools/src/input/to_numerical/float.rs
+++ b/my_rusttools/src/input/to_numerical/float.rs
@@ -91,12 +91,13 @@ where
         ///     Err(err) => println!("error: {}", err),
         /// }
         /// ```
-        fn take_float_include_range<U: RangeBounds<T>>(&self, range: &U) -> Result<T>{
-            Err(match self.take_float() {
-                Ok(float) if range.contains(&float) => return Ok(float),
-                Ok(_) => NumInputError{kind: NumInputErrorKind::OutsideValidRange},
-                Err(err) => err,
-            })
+        fn take_float_include_range<U: RangeBounds<T>>(&self, range: &U) -> Result<T> {
+            self.take_float()
+                .and_then(|x|if range.contains(&x) {
+                    Ok(x)
+                } else {
+                    Err(NumInputError{kind: NumInputErrorKind::OutsideValidRange})
+                })
         }
 
         /// Takes an floating point input,
@@ -115,11 +116,12 @@ where
         /// }
         /// ```
         fn take_float_exclude_range<U: RangeBounds<T>>(&self, range: &U) -> Result<T> {
-            Err(match self.take_float() {
-                Ok(float) if range.contains(&float) => NumInputError{kind: NumInputErrorKind::InInvalidRange},
-                Ok(float) => return Ok(float),
-                Err(err) => err,
-            })
+            self.take_float()
+                .and_then(|x|if range.contains(&x) {
+                    Err(NumInputError{kind: NumInputErrorKind::InInvalidRange},)
+                } else {
+                    Ok(x)
+                })
         }
 
         /// Takes an floating point input,

--- a/my_rusttools/src/input/to_numerical/int.rs
+++ b/my_rusttools/src/input/to_numerical/int.rs
@@ -92,11 +92,12 @@ where
         /// }
         /// ```
         fn take_int_include_range<U: RangeBounds<T>>(&self, range: &U) -> Result<T>{
-            Err(match self.take_int() {
-                Ok(int) if range.contains(&int) => return Ok(int),
-                Ok(_) => NumInputError{kind: NumInputErrorKind::OutsideValidRange},
-                Err(err) => err,
-            })
+            self.take_int()
+                .and_then(|x|if range.contains(&x) {
+                    Ok(x)
+                } else {
+                    Err(NumInputError{kind: NumInputErrorKind::OutsideValidRange},)
+                })
         }
 
         /// Takes an integer input,
@@ -115,11 +116,12 @@ where
         /// }
         /// ```
         fn take_int_exclude_range<U: RangeBounds<T>>(&self, range: &U) -> Result<T> {
-            Err(match self.take_int() {
-                Ok(int) if range.contains(&int) => NumInputError{kind: NumInputErrorKind::InInvalidRange},
-                Ok(int) => return Ok(int),
-                Err(err) => err,
-            })
+            self.take_int()
+                .and_then(|x|if range.contains(&x) {
+                    Err(NumInputError{kind: NumInputErrorKind::InInvalidRange})
+                } else {
+                    Ok(x)
+                })
         }
 
         /// Takes an integer input,


### PR DESCRIPTION
Refactors elements of the control flow for the include/exclude_range methods to make them more concise.