### PR TITLE
Revert "Major input handling rework + module path flattening"

### DIFF
--- a/my_rusttools/examples/guessing_game/main.rs
+++ b/my_rusttools/examples/guessing_game/main.rs
@@ -1,31 +1,21 @@
 use std::{
     cmp::Ordering,
-    process
+    io,
 };
 use rand::Rng;
-use my_rusttools::StdinExtended;
+use my_rusttools::input::TakeInputParse;
 
 fn main() {
     let secret: u8 = rand::thread_rng().gen_range(1..=100);
-    let cli_inp = StdinExtended::new();
+    let cli_inp = io::stdin();
     println!("Guess the number!");
 
     loop {
-        let guess: u8 = loop {
-            println!("Please enter a number from 1 to 100,");
-
-            match cli_inp.read_line_new_string()
-                .map_or_else(|err|{
-                    eprintln!("input error: {}", err);
-                    process::exit(1);
-                },
-                |x|x.trim().parse()
-                ) {
-                    Ok(guess) => break guess,
-                    Err(err) => eprintln!("invalid input: {}", err)
-                }
-        };
-
+        let guess: u8 = cli_inp.take_input_until_parsed_and_validated(
+                |x|(1..=100).contains::<u8>(&x),
+                ||println!("Please input a guess from 1 to 100:"),
+                |err|println!("invalid input: {}", err)
+            );
         println!("Your guess: {}", guess);
 
         match guess.cmp(&secret) {

--- a/my_rusttools/src/factories/iter_factories.rs
+++ b/my_rusttools/src/factories/iter_factories.rs
@@ -53,24 +53,6 @@ where
 /// Creates an iterator which returns
 /// the fizzbuzz sequence.
 /// 
-/// # Overflow Behaviour
-/// 
-/// The function does not guard against overflows,
-/// overflow in the [`Iterator`] implementation (when the contained
-/// data type reaches its numerical limit) is allowed to panic, wrap, or
-/// saturate. This behavior is defined by the implementation of the [`Step`]
-/// trait. For primitive integers, this follows the normal rules, and respects
-/// the overflow checks profile (panic in debug, wrap in release),
-/// so iterating more than [`usize::MAX`] elements,
-/// either produces the wrong result, or panics.
-/// If debug assertions are enabled, a panic is guaranteed.
-/// 
-/// Note also that overflow happens earlier than you might assume: the overflow happens
-/// in the call to `next` that yields the maximum value, as the range must be
-/// set to a state to yield the next value.
-/// 
-/// [`Step`]: std::iter::Step
-/// 
 /// # Examples
 /// ```
 /// # use my_rusttools::factories::fizzbuzz;
@@ -87,12 +69,14 @@ pub fn fizzbuzz() -> impl Iterator<Item = String> {
     // Zips the cycling sequence into a `Range`, indicating the current iteration,
     // appending and returning the values from the cycled sequence
     // or returning the current index if values were empty.
-    (1usize..).zip(fizzbuzz)
-        .map(|(i, (x, y))|
-            if x == y {
+    (1..=usize::MAX).zip(fizzbuzz)
+        .map(|(i, (x, y))| {
+            let ret = x.to_owned() + y;
+
+            if ret.is_empty() {
                 i.to_string()
             } else {
-                x.to_owned() + y
+                ret
             }
-        )
+        })
 }

--- a/my_rusttools/src/gcacher.rs
+++ b/my_rusttools/src/gcacher.rs
@@ -451,8 +451,8 @@ where
         /// to instance the cache cleanly.
         fn create(instancer: F, cache: HashMap<K, V, S>) -> GCacher<K, F, V, S> {
             Self {
-                instancer,
-                cache,
+                instancer: instancer,
+                cache: cache,
             }
         }
 

--- a/my_rusttools/src/input.rs
+++ b/my_rusttools/src/input.rs
@@ -1,175 +1,454 @@
 //! Custom input handling tools.
 use std::{
-    io::{self, Read},
-    ops::{Bound::*, RangeBounds, Deref, DerefMut, ControlFlow},
-    os::unix::prelude::AsRawFd,
+    io,
+    ops::{Bound::*, RangeBounds},
+    str::FromStr,
+    iter::{Map, Enumerate},
+    vec,
 };
 
-/// A newtype wrapper of [`std::io::Stdin`],
-/// to extend it with custom methods.
-/// 
-/// # Examples
-/// ```
-/// use my_rusttools::input::StdinExtended;
-///  
-/// let uinp = StdinExtended::new();
-/// println!("{:?}", uinp.read_line_new_string());
-#[derive(Debug)]
-pub struct StdinExtended(pub io::Stdin);
+/// An interface for taking basic input as strings.
+pub trait TakeInputBasic<T> {
+    /// Takes a line of input as a `String`.
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use std::io;
+    /// use my_rusttools::input::TakeInputBasic;
+    ///
+    /// let a = io::stdin().take_string_input();
+    /// println!("User input: {}", a);
+    /// ```
+    fn take_input(&self) -> String;
 
-impl StdinExtended {
-    /// Constructs a new extended version of the handle
-    /// to the standard input of the current process.
+    /// Takes a line of input as a `String`,
+    /// mapping it to `T` by applying the passed function.
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use std::io;
+    /// use my_rusttools::input::TakeInputBasic;
+    ///
+    /// match io::stdin().take_string_input_then_map(|mut x| {
+    ///     x.make_ascii_lowercase();
+    ///     let trimmed = x.trim();
+    ///
+    ///     if ["y", "yes"].contains(&trimmed) {
+    ///         Ok(true)
+    ///     } else if ["n", "no"].contains(&trimmed) {
+    ///         Ok(false)
+    ///     } else {
+    ///         Err("input must be \"y(es)\" or \"n(o)\"")
+    ///     }
+    /// }) {
+    ///     Ok(case) => println!("User's input was: {}", case),
+    ///     Err(err) => eprintln!("invalid input: {}", err),
+    /// }
+    /// ```
+    fn take_input_then_map<F>(&self, f: F) -> T
+    where
+        F: FnOnce(String) -> T, {
+            f(self.take_input())
+        }
+
+    /// Takes a line of input as a `String`,
+    /// mapping it to [`Option<T>`] by applying the passed function,
+    /// until a [`Some`] varient is returned.
+    /// 
+    /// # Closures
+    /// 
+    /// The signiture of this method features two closures,
+    /// one of which warrents explanation as to its usage:
+    /// 
+    /// 
+    /// ## `notif`
+    /// 
+    /// `notif` will be run at the beginning of each loop,
+    /// and is intended to allow the developer to push a notification
+    /// on the intended usage of the program.
     /// 
     /// # Examples
     /// 
-    /// Using implicit synchronization:
     /// ```
     /// use std::io;
-    /// use my_rusttools::input::StdinExtended;
+    /// use my_rusttools::input::TakeInputBasic;
     /// 
-    /// fn main() -> io::Result<()> {
-    ///     let uinp = StdinExtended::new();
-    ///     println!("{}", uinp.read_line_new_string()?);
-    ///     Ok(())
-    /// }
+    /// let uinp: usize = io::stdin()
+    ///     .take_string_input_until_mapped(
+    ///         |x|x.trim()
+    ///             .parse()
+    ///             .ok(), 
+    ///         ||println!("Please enter a posive whole number:")
+    /// );
+    /// 
+    /// println!("User input: {}", uinp);
     /// ```
     /// 
-    /// Using explicit syncronization:
-    /// ```
-    /// use my_rusttools::input::StdinExtended;
-    /// 
-    /// fn main() -> io::Result<()> {
-    ///     let mut buffer = String::new();
-    ///     let uinp = StdinExtended::new();
-    ///     let mut handle = uinp.lock();
-    /// 
-    ///     println!("{}", handle.read_line(&mut buffer)?);
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn new() -> Self {
-        Self(io::stdin())
-    }
+    /// [`Option<T>`]: std::option::Option
+    /// [`Some`]: std::option::Option::Some
+    fn take_input_until_mapped<F, G>(&self, mut f: F, mut notif: G) -> T
+    where
+        F: FnMut(String) -> Option<T>,
+        G: FnMut(), {
+            loop {
+                notif();
 
-    /// Locks the handle this type wraps and reads a line of input,
-    /// appending it to a new buffer.
+                if let Some(ret) = f(self.take_input()) {
+                    break ret;
+                }
+            }
+        }
+
+    /// Takes lines of input as a `String`,
+    /// between the bounds specified,
+    /// or until index limits are reached.
+    ///
+    /// # Limits
+    ///
+    /// Regardless of the number of iterations taking input,
+    /// the method should immediately return if the input `String`
+    /// reaches the maximum size.
+    /// 
+    /// # Closures
+    /// 
+    /// The signiture of this method features two closures,
+    /// which warrents explantation:
+    /// 
+    /// ## `notif`
+    /// 
+    /// `notif` will run at the beginning of each loop,
+    /// and is intended to allow the developer to push a notification
+    /// on the intended usage of the program.
+    /// 
+    /// In the case of this closure,
+    /// that also includes the index of the current iteration,
+    /// to allow behaviour to be differentiated by line,
+    /// as well as a string slice of the collective contents of the input thus far.
+    /// 
+    /// ## `err_notif`
+    /// 
+    /// `err_notif` will run if there is an error reading input,
+    /// and is intended to allow the developer to push a notification on the misinput,
+    /// as well as specify whether the function will proceed following this error.
+    /// 
+    /// Similarly to `notif`, `error_notif` is also provided with values
+    /// indicating the current state of the function,
+    /// allowing them to be incorperated into the behaviour of the closure.
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use std::io;
+    /// use my_rusttools::input::TakeInputBasic;
+    ///
+    /// let a = io::stdin().take_lines_input(
+    ///     |x, _|println!("Please input between 3 and 10 lines.\n{} number remaining.", 3 - x);,
+    ///     |err, x, _|{println!("input error: {}", err); x >= 3}, 
+    ///     3..10
+    /// );
+    /// assert!(a.lines().count() > 2);
+    /// ```
+    fn take_lines_input<U: RangeBounds<usize>, F, EF>(&self, notif: F, err_notif: EF, bounds: U) -> String
+    where
+        F: FnMut(usize, &str),
+        EF: FnMut(io::Error, usize, &str) -> bool;
+
+    /// Takes lines of input as a `String`,
+    /// between the bounds specified,
+    /// or until index limits are reached.
+    /// 
+    /// # Limits
+    /// 
+    /// Regardless of the number of iterations taking input,
+    /// the method should immediately return if the input `String`
+    /// reaches the maximum size.
+    /// 
+    /// # Closures
+    /// 
+    /// The signitiure of this method, features three closures,
+    /// two of which warrent explantation:
+    /// 
+    /// ## `notif`
+    /// 
+    /// `notif` will run at the beginning of each loop,
+    /// and is intended to allow the developer to push a notification
+    /// on the intended usage of the program.
+    /// 
+    /// In the case of this closure,
+    /// that also includes the index of the current iteration,
+    /// to allow behaviour to be differentiated by line,
+    /// as well as a string slice of the collective contents of the input thus far.
+    /// 
+    /// ## `err_notif`
+    /// 
+    /// `err_notif` will run if there is an error reading input,
+    /// and is intended to allow the developer to push a notification on the misinput,
+    /// as well as specify whether the function will proceed following this error.
+    /// 
+    /// Similarly to `notif`, `error_notif` is also provided with values
+    /// indicating the current state of the function,
+    /// allowing them to be incorperated into the behaviour of the closure.
     /// 
     /// # Examples
+    /// 
     /// ```
     /// use std::io;
-    /// use my_rusttools::input::StdinExtended;
+    /// use my_rusttools::input::TakeInputBasic;
     /// 
-    /// fn main() -> io::Result<()> {
-    ///     let uinp = StdinExtended::new();
-    ///     println!("{}", uinp.read_line_new_string()?);
-    ///     Ok(())
-    /// }
+    /// let a = io::stdin().take_lines_input(
+    ///     |x, _|println!("Please input between 3 and 10 numbers.\n{} numbers remaining.", 3 - x);,
+    ///     |err, x, _|{println!("input error: {}", err); x >= 3}, 
+    ///     |(_, x)|x.trim().parse::<isize>(),
+    ///     3..10
+    /// );
+    /// assert!(a.count() > 2);
     /// ```
-    pub fn read_line_new_string(&self) -> io::Result<String> {
+    fn take_lines_input_then_map<E, U: RangeBounds<usize>, F, G, EF>(&self, notif: G, err_notif: EF, f: F, bounds: U) -> Map<Enumerate<vec::IntoIter<String>>, F>
+    where
+        F: FnMut((usize, String)) -> T,
+        G: FnMut(usize, &str), 
+        EF: FnMut(io::Error, usize, &str) -> bool, {
+            self.take_lines_input(notif, err_notif, bounds)
+                .lines()
+                .map(|x|x.to_string())
+                .collect::<Vec<String>>()
+                .into_iter()
+                .enumerate()
+                .map(f)
+        }
+}
+
+impl<T> TakeInputBasic<T> for io::Stdin {
+    fn take_input(&self) -> String {
         let mut ret = String::new();
 
-        self.read_line(&mut ret).map(|_|ret)
+        self.read_line(&mut ret).expect("failed to read input");
+
+        ret
     }
 
-    /// Repeatedly locks the handle this type warps,
-    /// reading a number of lines within the range specified,
-    /// to a new buffer.
-    /// 
-    /// # Examples
-    /// ```
-    /// use std::io;
-    /// use my_rusttools::input::StdinExtended;
-    /// use std::ops::ControlFlow;
-    /// 
-    /// fn main() -> io::Result<()> {
-    ///     let uinp = StdinExtended::new();
-    ///     let input = uinp.read_lines(1..=3,
-    ///         |curr|println!("Please enter between 1 and 3 lines.\nCurrent count: {}", curr.lines().count()),
-    ///         |err, curr|{
-    ///             eprintln!("input error: {}\nerror at {}", err, curr);
-    ///             ControlFlow::Break(())
-    ///         }
-    ///     )?;
-    /// 
-    ///     println!("{}", input);
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn read_lines<U: RangeBounds<usize>, F, EF>(&self, bounds: U, mut notif: F, mut err_notif: EF) -> io::Result<String> where
-    F: FnMut(&str),
-    EF: FnMut(&io::Error, &str) -> ControlFlow<()> {
+    fn take_lines_input<U: RangeBounds<usize>, F, EF>(&self, mut notif: F, mut err_notif: EF, bounds: U) -> String 
+    where
+        F: FnMut(usize, &str),
+        EF: FnMut(io::Error, usize, &str) -> bool, {
         let mut ret = String::new();
-        let mut line_count = 0;
-
+        let mut iterations = 0;
         let start = *match bounds.start_bound() {
             Included(start) => start,
             Excluded(start) => start,
             Unbounded => &0,
         };
-
         let end = match bounds.end_bound() {
             Included(end) => *end,
-            Excluded(end) => end -1,
+            Excluded(end) => end - 1,
             Unbounded => usize::MAX,
         };
 
         loop {
-            if line_count >= end || line_count == usize::MAX {
-                break Ok(ret);
+            if iterations >= end || iterations >= usize::MAX {
+                break;
             }
 
-            notif(ret.as_str());
+            notif(iterations, ret.as_str());
 
-            if let Err(err) = self.read_line(&mut ret) {
-                if let ControlFlow::Break(()) = err_notif(&err, ret.as_str()) {
-                    break Err(err);
+            let size = match self.read_line(&mut ret) {
+                Ok(size) => size,
+                Err(err) => {
+                    if err_notif(err, iterations, ret.as_str()) {
+                        break;
+                    }
+
+                    0
+                },
+            }.checked_sub(2)
+                .unwrap_or_default();
+
+            if size > 1 {
+                iterations += 1
+            } else {
+                ret.truncate(ret.len() - 2);
+                if iterations >= start {
+                    break;
+                }
+            }
+        }
+
+        ret
+    }
+}
+
+pub trait TakeInputParse<T, E> 
+where
+    T: FromStr<Err = E>, {
+        /// Takes input from a buffer,
+        /// parsing it into another type.
+        /// 
+        /// # Errors
+        /// 
+        /// Will return [`Err`] if it's not possible to parse the input into the desired type.
+        /// 
+        /// # Examples
+        /// 
+        /// ```
+        /// use std::io;
+        /// use my_rusttools::input::TakeInputParse;
+        /// 
+        /// match io::stdin().take_input_parse::<usize>() {
+        ///     Ok(inp) => println!("User input: {}", inp),
+        ///     Err(err) => eprintln!("invalid input: {}", err),
+        /// }
+        /// ```
+        fn take_input_then_parse(&self) -> Result<T, E>;
+
+        /// Takes input from a buffer,
+        /// parsing it into another type
+        /// until it's parsed sucessfully.
+        /// 
+        /// # Closures
+        /// 
+        /// The signiture for this method features two closures,
+        /// warrenting explanation as to their purpose:
+        /// 
+        /// ## `notif`
+        /// 
+        /// `notif` will be run at the beginning of every loop,
+        /// and is intended to allow the developer to push a notification
+        /// on the expected usage of the program.
+        /// 
+        /// ## `err_notif`
+        /// 
+        /// `err_notif` will be run if there is an error parsing the input,
+        /// and is intended to allow the developer to push a notification
+        /// on the misinput, and the expected usage of the program.
+        /// 
+        /// # Examples
+        /// 
+        /// ```
+        /// use std::io;
+        /// use my_rusttools::input::TakeInputParse;
+        /// 
+        /// let uinp: usize = io::stdin().take_input_until_parsed(
+        ///     ||println!("Please enter a positive whole number:"),
+        ///     |err|println!("invalid input: {}", err)
+        /// );
+        /// 
+        /// println!("User input: {}", uinp);
+        /// ```
+        fn take_input_until_parsed<F, EF>(&self, mut notif: F, mut err_notif: EF) -> T
+        where
+            F: FnMut(),
+            EF: FnMut(E), {
+                loop {
+                    notif();
+
+                    match self.take_input_then_parse() {
+                        Ok(ret) => break ret,
+                        Err(err) => err_notif(err),
+                    }
                 }
             }
 
-            let new_line_count = ret.trim().lines().filter(|x|!x.is_empty()).count();
+        /// Takes input from a buffer,
+        /// parsing into another type
+        /// until it's parsed sucessfully,
+        /// and the resulting value is validated by the passed function.
+        /// 
+        /// # Closures
+        /// 
+        /// The signiture for this method features three closures,
+        /// warrenting explanation as to their purpose:
+        /// 
+        /// ## `validate`
+        /// 
+        /// `validate` is applied to the resulting value from parsing the buffer input,
+        /// only breaking from reading from the buffer where the predicate returns `true`.
+        /// In the case of an invalid input, this sould also be used to notiy users of why it was invalidated.
+        /// 
+        /// ## `notif`
+        /// 
+        /// `notif` will be run at the beginning of every loop,
+        /// and is intended to allow the developer to push a notification
+        /// on the expected usage of the program.
+        /// 
+        /// ## `err_notif`
+        /// 
+        /// `err_notif` will be run if there is an error parsing the input,
+        /// and is intended to allow the developer to push a notification
+        /// on the misinput, and the expected usage of the program.
+        /// 
+        /// # Examples
+        /// 
+        /// ```
+        /// use std::io;
+        /// use my_rusttools::input::TakeInputParse;
+        /// 
+        /// let proceed: bool = io::stdin().take_input_until_parsed_and_valid(
+        ///     |x|x,
+        ///     ||println!("Enter 'true'."),
+        ///     |err|println!("invalid input: {}", err)
+        /// );
+        /// 
+        /// assert!(proceed);
+        /// ```
+        fn take_input_until_parsed_and_validated<F, EF, V>(&self, mut validate: V, mut notif: F, mut err_notif: EF) -> T
+        where
+            F: FnMut(),
+            EF: FnMut(E),
+            V: FnMut(&T) -> bool, {
+                loop {
+                    let ret = self.take_input_until_parsed(&mut notif, &mut err_notif);
 
-            if new_line_count - line_count < 1 && new_line_count.checked_sub(start).is_some() {
-                break Ok(ret);
-            } else {
-                ret = ret.lines()
-                    .filter(|x|!x.is_empty())
-                    .fold(String::new(), |acc, x|acc + x + "\n");
+                    if validate(&ret) {
+                        break ret;
+                    }
+                }
             }
+    }
 
-            line_count = new_line_count;
+impl<T, E, V> TakeInputParse<T, E> for V
+where
+    T: FromStr<Err = E>,
+    V: TakeInputBasic<T>, {
+        fn take_input_then_parse(&self) -> Result<T, E> {
+            self.take_input()
+                .trim()
+                .parse()
         }
     }
-}
 
-impl Deref for StdinExtended {
-    type Target = io::Stdin;
+#[cfg(test)]
+mod input_tests {
+    use super::*;
+    use std::io;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[test]
+    fn mapping_test() {
+        match io::stdin().take_input_then_map(|mut x| {
+            x.make_ascii_lowercase();
+            let trimmed = x.trim();
+
+            Ok(if ["y", "yes"].contains(&trimmed) {
+                true
+            } else if ["n", "no"].contains(&trimmed) {
+                false
+            } else {
+                return Err("input must be \"y(es)\" or \"n(o)\"");
+            })
+        }) {
+            Ok(case) => println!("User's input was: {}", case),
+            Err(err) => println!("invalid input: {}", err),
+        };
     }
-}
 
-impl DerefMut for StdinExtended {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
+    #[test]
+    fn mapping_test_two() {
+        let uinp: usize = io::stdin().take_input_until_mapped(|x|
+            x.trim()
+            .parse()
+            .ok(), ||println!("Please enter a posive whole number:"));
 
-impl Read for StdinExtended {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
-    }
-}
-
-impl AsRawFd for StdinExtended {
-    fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
-        self.0.as_raw_fd()
-    }
-}
-
-impl Default for StdinExtended {
-    fn default() -> Self {
-        Self::new()
+        println!("User input: {}", uinp);
     }
 }

--- a/my_rusttools/src/lib.rs
+++ b/my_rusttools/src/lib.rs
@@ -1,10 +1,7 @@
 pub mod factories;
-mod gcacher;
-mod input;
+pub mod gcacher;
+pub mod input;
 pub mod traits;
-
-pub use gcacher::GCacher;
-pub use input::StdinExtended;
 
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/my_rusttools/tests/factory_tests.rs
+++ b/my_rusttools/tests/factory_tests.rs
@@ -40,10 +40,3 @@ fn ref_test() {
         _ => None
     });
 }
-
-#[test]
-#[should_panic]
-#[ignore = "really long process times, attemping usize overflow"]
-fn fizzbuzz_is_infinite() {
-    fizzbuzz().skip(usize::MAX).for_each(|x|println!("{}", x));
-}

--- a/my_rusttools/tests/gcacher_tests.rs
+++ b/my_rusttools/tests/gcacher_tests.rs
@@ -1,7 +1,7 @@
 #![allow(unused_assignments, unused_variables)]
 use std::collections::HashMap;
 
-use my_rusttools::GCacher;
+use my_rusttools::gcacher::*;
     
 #[test]
 fn it_works() {

--- a/my_rusttools/tests/input_handling.rs
+++ b/my_rusttools/tests/input_handling.rs
@@ -1,115 +1,74 @@
 #![allow(unused_comparisons)]
-use std::ops::ControlFlow;
-use my_rusttools::StdinExtended;
+use my_rusttools::input::*;
+use std::io;
 
 #[test]
-#[ignore = "input testing"]
+#[ignore]
 fn until_parsed_test() {     
-    let uinp = StdinExtended::new();
-    let num: usize = loop {
-        println!("Please enter a positive whole number,");
-
-        match uinp.read_line_new_string()
-            .map_or_else(|err|panic!("input error: {}", err), |x|x.trim().parse()) {
-                Ok(num) => break num,
-                Err(err) => eprintln!("invalid input: {}", err),
-            }
-    };
+    let num: usize = io::stdin()
+        .take_input_until_parsed(
+            ||println!("Please enter a positive number:"),
+            |err|println!("invalid input: {}", err)
+        );
      
     assert!(num >= 0);
 }
 
 #[test]
-#[ignore = "input testing"]
-fn until_valid_include_test() { 
-    let uinp = StdinExtended::new();    
-    let num: usize = loop {
-        println!("Please enter a positive whole number, up to 100,");
-
-        match uinp.read_line_new_string()
-            .map_or_else(|err|panic!("input error: {}", err), |x|x.trim().parse()) {
-                Ok(num) if (..100).contains(&num) => break num,
-                Ok(num) => eprintln!("invalid input: {} greater than 100", num),
-                Err(err) => eprintln!("invalid input: {}", err)
-            }
-    };
+#[ignore]
+fn until_valid_include_test() {     
+    let num: usize = io::stdin()
+        .take_input_until_parsed_and_validated(
+            |x|(..=100).contains::<usize>(&x),
+            ||println!("Please enter a positive number up to 100:"),
+            |err|println!("invalid input: {}", err)
+        );
      
     assert!(num <= 100);
 }
 
 #[test]
-#[ignore = "input testing"]
+#[ignore]
 fn until_valid_exclude_test() {     
-    let uinp = StdinExtended::new();
-    let num: usize = loop {
-        println!("Please enter a number greater than 10,");
-
-        match uinp.read_line_new_string()
-            .map_or_else(|err|panic!("input error: {}", err), |x|x.trim().parse()) {
-                Ok(num) if !(..=10).contains(&num) => break num,
-                Ok(num) => eprintln!("invalid input: {} less than/equal to 10", num),
-                Err(err) => eprintln!("invalid input: {}", err),
-            }
-    };
+    let num: usize = io::stdin()
+        .take_input_until_parsed_and_validated(
+            |x|!(..=10).contains::<usize>(&x),
+            ||println!("Please enter a number greater than 10:"),
+            |err|println!("invalid input: {}", err)
+        );
      
     assert!(num > 10);
 }
 
 #[test]
-#[ignore = "input testing"]
+#[ignore]
 fn float_until_parsed_test() {
-    let uinp = StdinExtended::new();
-    let num: f64 = loop {
-        println!("Please enter a decimal number,");
-
-        match uinp.read_line_new_string()
-            .map_or_else(|err|panic!("input error: {}", err), |x|x.trim().parse()) {
-                Ok(num) => break num,
-                Err(err) => eprintln!("invalid input: {}", err),
-            }
-    };
+    let num: f64 = io::stdin()
+        .take_input_until_parsed(
+            ||println!("Please enter a positive number:"),
+            |err|println!("invalid input: {}", err)
+        );
  
     assert!(num >= f64::MIN);   
 }
 
 #[test]
-#[ignore = "input testing"]
+#[ignore]
 fn yes_no() {
-    let uinp = StdinExtended::new();
-    let uinp = loop {
-        println!("Please enter \"y(es)\" or \"n(o)\"");
-
-        let ret = uinp.read_line_new_string()
-            .map_or_else(|err|panic!("input error: {}", err), |mut x|{
+    assert!([true, false].contains(&io::stdin()
+        .take_input_until_mapped(
+            |mut x| {
                 x.make_ascii_lowercase();
+                let trimmed = x.trim();
 
-                match x.trim() {
-                    "y" | "yes" => Ok(true),
-                    "n" | "no" => Ok(false),
-                    other => {
-                        eprintln!("invalid input: {}", other);
-                        Err(())
-                    },
+                if ["yes", "y"].contains(&trimmed) {
+                    Some(true)
+                } else if ["no", "n"].contains(&trimmed) {
+                    Some(false)
+                } else {
+                    None
                 }
-            });
-
-        if let Ok(ret) = ret {
-            break ret;
-        }
-    };
-
-    assert!([true, false].contains(&uinp));
-}
-
-#[test]
-#[ignore = "input testing"]
-fn lines_test() {
-    let lines = StdinExtended::new().read_lines(1..=3, 
-        |x|println!("Please enter up to 3 values.\nCurrent count: {}", x.lines().count()), 
-        |_, _|ControlFlow::Break(())
-    ).expect("input error")
-        .lines()
-        .count();
-
-    assert!((1..4).contains(&lines));
+            },
+            ||println!("Please enter 'y(es)' or 'n(o)':"))
+        ));
 }


### PR DESCRIPTION
Reverting this PR to allow `my_rusttools_dev` to be fast-forwarded to match it.